### PR TITLE
Setup unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project is my third rewrite of a custom UNIX-like shell, developed as a han
 ### 0.1.1
     
 - [ ] Setup unit testing
+- [ ] Add logs
 
 ### 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -4,39 +4,21 @@ This project is my third rewrite of a custom UNIX-like shell, developed as a han
 
 ## Roadmap
 
-### 0.1.0 
-
 - [x] Parse config file
 - [x] Clears CLI on startup
-- [x] Show QOTD on startup
-
-### 0.1.1
-    
-- [ ] Setup unit testing
+- [x] Show QOTD on startup    
+- [x] Setup unit testing
 - [ ] Add logs
-
-### 0.2.0
-
 - [ ] Parse command line input
 - [ ] Execute single parsed command per line
     - [ ] Check return call of all system calls
     - [ ] White space and tab handling
-
-### 0.2.1
-
 - [ ] Parse batched command from txt file
 - [ ] Execute single parsed command per line
     - [ ] Check return call of all system calls
     - [ ] White space and tab handling
-
-### 0.3.0
-
 - [ ] Redirection of ouput to a file
-
-### 0.4.0
-
 - [ ] Parallel commands
-
 
 ## Acknowledgments
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -172,7 +172,7 @@ func TestInitShellConfigValidConfigFile(t *testing.T) {
     }
 
     if (config.Path != "/usr/bin" || config.PromptColor != "\033[35m" || config.QuoteList[0] != "quote 1" || config.QuoteList[1] != "quote 2") {
-        t.Errorf("config path doesnt have right values")
+        t.Errorf("config.InitShellConfig(%v), should return a valid configuration with values (%v, %v, %v )", filePath, config.Path, config.PromptColor, config.QuoteList)
     }
 
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,185 @@
+package config_test
+
+import (
+	"gosh/config"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSetConfigValuesEmptyFile(t *testing.T) {
+    initialShellConfig := config.ShellConfig{}
+    configLines := []string{""}
+    shellConfig := config.SetConfigValues(initialShellConfig, strings.TrimSpace(configLines[0]))
+
+    if shellConfig.PromptColor != "" || shellConfig.Path != "" || len(shellConfig.QuoteList ) > 0 {
+        t.Errorf("config.SetConfigValues(%q), config values should be empty, actual %q", configLines[0], config.GlobalShellConfig)
+    }
+}
+
+func TestSetConfigValuesWithEmptyValues(t *testing.T) {
+    initialShellConfig := config.ShellConfig{}
+    configLines := []string{"prompt_color=", "path=", "qotd_list="}
+    
+    shellConfig := config.SetConfigValues(initialShellConfig, strings.TrimSpace(configLines[0]))
+    shellConfig = config.SetConfigValues(shellConfig, strings.TrimSpace(configLines[1]))
+    shellConfig = config.SetConfigValues(shellConfig, strings.TrimSpace(configLines[2]))
+
+    if shellConfig.PromptColor != "" || shellConfig.Path != "" || len(shellConfig.QuoteList ) > 0 {
+        t.Errorf("config.SetConfigValues(%q | %q | %q), config values should be empty, actual %q", configLines[0], configLines[1], configLines[2], shellConfig)
+        return
+    }
+}
+
+func TestSetConfigValuesWithSetValues(t *testing.T) {
+    initialShellConfig := config.ShellConfig{}
+    configLines := []string{
+        "prompt_color=\033[35m", 
+        "path=~/something/:/usr/bin:~/binaries", 
+        "qotd_list=All that is gold does not glitter,Not all those who wander are lost,I wish it need not have happened in my time said Frodo.",
+    }
+    
+    shellConfig := config.SetConfigValues(initialShellConfig, configLines[0])
+    shellConfig = config.SetConfigValues(shellConfig, configLines[1])
+    shellConfig = config.SetConfigValues(shellConfig, configLines[2])
+
+    if shellConfig.PromptColor != "\033[35m" || shellConfig.Path != "~/something/:/usr/bin:~/binaries" || len(shellConfig.QuoteList ) != 3 {
+        t.Errorf("config.SetConfigValues(%q | %q | %q), config values should be empty, actual %q", configLines[0], configLines[1], configLines[2], shellConfig)
+    }
+}
+
+func TestSetConfigValuesWithEmptySpacesInValues(t *testing.T) {
+    initialShellConfig := config.ShellConfig{}
+    configLines := []string{
+        "prompt_color=          ", 
+        "path=          ", 
+        "qotd_list=          ",
+    }
+    
+    shellConfig := config.SetConfigValues(initialShellConfig, configLines[0])
+    shellConfig = config.SetConfigValues(shellConfig, configLines[1])
+    shellConfig = config.SetConfigValues(shellConfig, configLines[2])
+
+    if shellConfig.PromptColor != "" || shellConfig.Path != "" || len(shellConfig.QuoteList ) != 0 {
+        t.Errorf("config.SetConfigValues(%q | %q | %q), config values should be empty, actual %q", configLines[0], configLines[1], configLines[2], shellConfig)
+    }
+}
+
+func TestSetConfigValuesWithTabsInValues(t *testing.T) {
+    initialShellConfig := config.ShellConfig{}
+    configLines := []string{
+        "prompt_color=			", 
+        "path=				", 
+        "qotd_list=				",
+    }
+    
+    shellConfig := config.SetConfigValues(initialShellConfig, configLines[0])
+    shellConfig = config.SetConfigValues(shellConfig, configLines[1])
+    shellConfig = config.SetConfigValues(shellConfig, configLines[2])
+
+    if shellConfig.PromptColor != "" || shellConfig.Path != "" || len(shellConfig.QuoteList ) != 0 {
+        t.Errorf("config.SetConfigValues(%q | %q | %q), config values should be empty, actual %q", configLines[0], configLines[1], configLines[2], shellConfig)
+    }
+}
+
+func TestInitShellConfigFileNotFound(t *testing.T) {
+    filePath := "./non_existent.rc"
+
+    config, initConfigErr := config.InitShellConfig(filePath)
+
+    expectedError := "file not found: could not open shell's configuration file"
+    if initConfigErr.Error() != expectedError {
+        t.Errorf("config.InitShellConfig(%v), should return (%v) when file doesn't exist", filePath, expectedError)
+    }
+
+    if (config.Path == "" && config.PromptColor == "" && len(config.QuoteList) > 0) {
+        t.Errorf("config.InitShellConfig(%v), should return empty Path, PromptColor, and QuoteList", filePath)
+    }
+}
+
+func TestInitShellConfigPermissionDenied(t *testing.T) {
+    filePath := "testfile.txt"
+    testFile, err := os.Create(filePath)
+    if err != nil {
+        t.Fatalf("could not create file.")
+    }
+    testFile.Close()
+
+    err = os.Chmod(filePath, 0220) // 0 + 2 + 0 (-w-)
+    if (err != nil) {
+        t.Fatalf("could not change file's permissions.")
+    }
+
+
+    config, initConfigErr := config.InitShellConfig(filePath)
+    expectedError := "permission denied: could not open shell's configuration file"
+    if initConfigErr.Error() != expectedError {
+        t.Errorf("config.InitShellConfig(%v), should return (%v) when file's permissions are 0000", filePath, expectedError)
+    }
+
+    if config.Path == "" && config.PromptColor == "" && len(config.QuoteList) > 0 {
+        t.Errorf("config.InitShellConfig(%v), should return empty Path, PromptColor, and QuoteList", filePath)
+    }
+
+
+    t.Cleanup(func () {
+        err = os.Remove(filePath);
+        if err != nil {
+            t.Errorf("Error deleting file: ")
+        }
+    })
+}    
+
+func TestInitShellConfigInvalidConfigFile(t *testing.T) {
+    filePath := "invalid_config_file.txt"
+    data := []byte("prompt_color====\npath======\n");
+
+    err := os.WriteFile(filePath, data, 0664)
+    if (err != nil) {
+        t.Fatalf("could not write to file %v", filePath)
+    }
+
+
+    _, initConfigErr := config.InitShellConfig(filePath)
+    expectedErr := "invalid configuration"
+    if (initConfigErr.Error() != expectedErr) {
+        t.Errorf("config.InitShellConfig(%v), should return 'invalid configuration' error", filePath)
+    }
+
+
+    t.Cleanup(func () {
+        // os cleanup?
+        err = os.Remove(filePath);
+        if err != nil {
+            t.Errorf("Error deleting file: ")
+        }
+    })
+}
+
+func TestInitShellConfigValidConfigFile(t *testing.T) {
+    filePath := "valid_file.rc"
+    data := []byte("prompt_color=\033[35m\npath=/usr/bin\nqotd_list=quote 1,quote 2");
+
+    err := os.WriteFile(filePath, data, 0664)
+    if (err != nil) {
+        t.Fatalf("could not write to file %v", filePath)
+    }
+
+
+    config, initConfigErr := config.InitShellConfig(filePath)
+    if (initConfigErr != nil) {
+        t.Errorf("config.InitShellConfig(%v), should return a valid configuration file and not error", filePath)
+    }
+
+    if (config.Path != "/usr/bin" || config.PromptColor != "\033[35m" || config.QuoteList[0] != "quote 1" || config.QuoteList[1] != "quote 2") {
+        t.Errorf("config path doesnt have right values")
+    }
+
+
+    t.Cleanup(func () {
+        err = os.Remove(filePath);
+        if err != nil {
+            t.Errorf("Error deleting file: ")
+        }
+    })
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"gosh/config"
+	"log"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -28,7 +29,9 @@ func printRandomQuote() {
 func main() {
     exec_clear()
 
-    config.InitShellConfig()
-
+    _, initShellConfigErr := config.InitShellConfig("./gosh.rc")
+    if (initShellConfigErr != nil) {
+        log.Fatal(initShellConfigErr)
+    }
     printRandomQuote()
 }


### PR DESCRIPTION
This pull request includes several changes to the configuration handling and testing of the shell project. The most important changes involve refactoring the configuration logic to return errors, making the `ShellConfig` struct public, and adding comprehensive unit tests for the configuration functions.

Configuration handling improvements:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L37-R70): Refactored `InitShellConfig` to return errors instead of printing them, and changed `shellConfig` to `ShellConfig` to make it public. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L37-R70) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L94-R121)

Testing enhancements:

* [`config/config_test.go`](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R1-R185): Added comprehensive unit tests for `SetConfigValues` and `InitShellConfig` to cover various scenarios, including empty values, valid configurations, and error cases.

Miscellaneous:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L6-L12): Removed unused imports and constants to clean up the code.