### PR TITLE
Implement exit builtin command.

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -101,6 +101,8 @@ func ExecuteCommands(wg *sync.WaitGroup, commands [][]string) {
                         fmt.Println(cdError)
                     }
                 }
+            } else if command[0] == "exit" {
+                syscall.Exit(0)
             } else {
                 pid, err := ExecuteCommand(command)
                 if err != nil {


### PR DESCRIPTION
## Summary

Implement exit builtin command, by just calling the corresponding syscall.